### PR TITLE
Improve hints with LaTeX and add animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,25 +120,39 @@
       border-color: var(--primary-color);
       background-color: #eff6ff;
     }
-    .option-card.selected {
-      border-color: var(--primary-color);
-      background-color: #e0f2fe;
-    }
-    .hint-card {
-      background-color: #ecfdf5;
-      border: 1px solid var(--success-color);
-      border-radius: 0.75rem;
-      padding: 1rem;
-      margin-top: 1rem;
-      position: relative;
-    }
-    .hint-card::before {
-      content: '💡';
-      position: absolute;
-      top: 0.75rem;
-      right: 0.75rem;
-      font-size: 1.5rem;
-    }
+.option-card.selected {
+  border-color: var(--primary-color);
+  background-color: #e0f2fe;
+  animation: pulse 0.3s ease;
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+.hint-card {
+  background-color: #ecfdf5;
+  border: 1px solid var(--success-color);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin-top: 1rem;
+  position: relative;
+  opacity: 0;
+  transform: scale(0.95);
+  transition: all 0.3s ease;
+}
+.hint-card::before {
+  content: '💡';
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  font-size: 1.5rem;
+}
+.hint-card.show {
+  opacity: 1;
+  transform: scale(1);
+}
     .progress-container {
       width: 100%;
       height: 0.5rem;
@@ -148,13 +162,13 @@
       overflow: hidden;
       position: relative;
     }
-    .progress-bar {
-      height: 100%;
-      background-color: var(--primary-color);
-      border-radius: 1rem;
-      transition: width 0.5s ease;
-      position: relative;
-    }
+      .progress-bar {
+        height: 100%;
+        background: linear-gradient(90deg, var(--primary-color), var(--secondary-color));
+        border-radius: 1rem;
+        transition: width 0.5s ease;
+        position: relative;
+      }
     .result-card {
       text-align: center;
       padding: 3rem 2rem;
@@ -527,6 +541,9 @@
       }
     ];
 
+    // Añadir una pista extra en LaTeX a cada pregunta
+    questions.forEach(q => q.hints.push('Revisa cada paso cuidadosamente \\textit{paso a paso}.'));
+
     // Función para barajar las opciones y actualizar el índice de la respuesta correcta.
     function shuffleOptions(question) {
       for (let i = question.options.length - 1; i > 0; i--) {
@@ -590,7 +607,8 @@
       if (currentHint < question.hints.length) {
         const hintContainer = document.getElementById('hintContainer');
         hintContainer.style.display = 'block';
-        hintContainer.innerHTML = question.hints[currentHint];
+        hintContainer.innerHTML = `\\(\\text{${question.hints[currentHint]}}\\)`;
+        hintContainer.classList.add('show');
         currentHint++;
         MathJax.Hub.Queue(["Typeset", MathJax.Hub, hintContainer]);
       }


### PR DESCRIPTION
## Summary
- animate option selection and hints
- render hints in MathJax and add an extra default hint
- give progress bar a gradient style

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6862d0dde7f8832098ded8991d27f45c